### PR TITLE
PDE-10458: Upgrade dependencies for Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,10 @@ setup(name='tap-sendgrid',
       url='http://singer.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_sendgrid'],
-      install_requires=['singer-python==5.0.4',
-                        'requests==2.13.0',
-                        'pendulum==1.2.0',
+      python_requires='>=3.9',
+      install_requires=['singer-python>=6,<7',
+                        'requests>=2.31,<3',
+                        'pendulum>=3,<4',
                         ],
       entry_points='''
           [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,9 @@ setup(name='tap-sendgrid',
       classifiers=['Programming Language :: Python :: 3 :: Only'],
       py_modules=['tap_sendgrid'],
       python_requires='>=3.9',
-      install_requires=['singer-python>=6,<7',
-                        'requests>=2.31,<3',
-                        'pendulum>=3,<4',
+      install_requires=['singer-python==6.1.1',
+                        'requests==2.32.3',
+                        'pendulum==3.0.0',
                         ],
       entry_points='''
           [console_scripts]


### PR DESCRIPTION
## Summary
- Bumps `requests`, `singer-python`, `pendulum` to Python 3.11-compatible versions
- Adds `python_requires=">=3.9"`

## Context
After the Python 3.9→3.11 upgrade (PDE-10351), this tap crashes on import:
```
ImportError: cannot import name 'Mapping' from 'collections'
```
Root cause: `requests==2.13.0` → `urllib3==1.22` uses `collections.Mapping`, removed in Python 3.10.

Jira: [PDE-10458](https://simondata.atlassian.net/browse/PDE-10458)

## Test plan
- [ ] Re-run the SendGrid Singer extract Jenkins job and confirm it passes
- [ ] Verify extracted data lands in S3 as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PDE-10458]: https://simondata.atlassian.net/browse/PDE-10458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ