### PR TITLE
Post-python update fix: access selected streams directly instead of is_selected

### DIFF
--- a/tap_sendgrid/context.py
+++ b/tap_sendgrid/context.py
@@ -36,10 +36,10 @@ class Context(object):
         self._catalog = catalog
         self.selected_stream_ids = set(
             [s.tap_stream_id for s in catalog.streams
-             if s.is_selected()]
+             if s.schema.selected]
         )
         self.selected_catalog = [s for s in catalog.streams
-                                 if s.is_selected()]
+                                 if s.schema.selected]
 
     def get_bookmark(self, path):
         return bks_.get_bookmark(self.state, *path)


### PR DESCRIPTION
* Post-upgrade, all sendgrid taps are failing with: TypeError: 'NoneType' object is not iterable error
* This PR replaces is_selected() with schema.selected in context.py to be compatible with singer-python 6.x